### PR TITLE
Update to latest Jaeger

### DIFF
--- a/csharp/src/Library/Library.csproj
+++ b/csharp/src/Library/Library.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jaeger" Version="0.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.1" />
+    <PackageReference Include="Jaeger" Version="0.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.2" />
   </ItemGroup>
 
 </Project>

--- a/csharp/src/Library/Library.csproj
+++ b/csharp/src/Library/Library.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jaeger" Version="0.0.10" />
+    <PackageReference Include="Jaeger" Version="0.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.2" />
   </ItemGroup>
 

--- a/csharp/src/extracredit/README.md
+++ b/csharp/src/extracredit/README.md
@@ -2,9 +2,13 @@
 
 Adding manual instrumentation to ASP.NET Core like we did in [Lesson 3](../lesson03)
 is tedious. Fortunately, we don't need to do that because that instrumentation itself already exists
-as open source modules:
+as open source module:
 
   * https://github.com/opentracing-contrib/csharp-netcore
+
+There is also an open source module for instrumenting gRPC server and client code:
+
+  * https://github.com/opentracing-contrib/csharp-grpc
 
 For an extra credit, try to use these modules to avoid instrumenting your code manually.
 

--- a/csharp/src/lesson01/exercise/Hello.cs
+++ b/csharp/src/lesson01/exercise/Hello.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Jaeger.Core;
-using Jaeger.Core.Reporters;
-using Jaeger.Transport.Thrift.Transport;
 using Microsoft.Extensions.Logging;
+using OpenTracing.Tutorial.Library;
 
 namespace OpenTracing.Tutorial.Lesson01.Exercise
 {

--- a/csharp/src/lesson01/solution/Hello.cs
+++ b/csharp/src/lesson01/solution/Hello.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using OpenTracing.Tutorial.Library;
 
 namespace OpenTracing.Tutorial.Lesson01.Solution
@@ -7,10 +8,12 @@ namespace OpenTracing.Tutorial.Lesson01.Solution
     internal class Hello
     {
         private readonly ITracer _tracer;
+        private readonly ILogger<Hello> _logger;
 
-        public Hello(ITracer tracer)
+        public Hello(ITracer tracer, ILoggerFactory loggerFactory)
         {
             _tracer = tracer;
+            _logger = loggerFactory.CreateLogger<Hello>();
         }
 
         public void SayHello(string helloTo)
@@ -24,7 +27,7 @@ namespace OpenTracing.Tutorial.Lesson01.Solution
                     ["value"] = helloString
                 }
             );
-            Console.WriteLine(helloString);
+            _logger.LogInformation(helloString);
             span.Log("WriteLine");
             span.Finish();
         }
@@ -36,10 +39,13 @@ namespace OpenTracing.Tutorial.Lesson01.Solution
                 throw new ArgumentException("Expecting one argument");
             }
 
-            var helloTo = args[0];
-            using (var tracer = Tracing.Init("hello-world"))
+            using (var loggerFactory = new LoggerFactory().AddConsole())
             {
-                new Hello(tracer).SayHello(helloTo);
+                var helloTo = args[0];
+                using (var tracer = Tracing.Init("hello-world", loggerFactory))
+                {
+                    new Hello(tracer, loggerFactory).SayHello(helloTo);
+                }
             }
         }
     }

--- a/csharp/src/lesson02/exercise/Hello.cs
+++ b/csharp/src/lesson02/exercise/Hello.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using OpenTracing.Tutorial.Library;
 
 namespace OpenTracing.Tutorial.Lesson02.Exercise

--- a/csharp/src/lesson02/solution/HelloActive.cs
+++ b/csharp/src/lesson02/solution/HelloActive.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using OpenTracing.Tutorial.Library;
 
 namespace OpenTracing.Tutorial.Lesson02.Solution
@@ -7,10 +8,12 @@ namespace OpenTracing.Tutorial.Lesson02.Solution
     internal class HelloActive
     {
         private readonly ITracer _tracer;
+        private readonly ILogger<HelloActive> _logger;
 
-        public HelloActive(ITracer tracer)
+        public HelloActive(ITracer tracer, ILoggerFactory loggerFactory)
         {
             _tracer = tracer;
+            _logger = loggerFactory.CreateLogger<HelloActive>();
         }
 
         private string FormatString(string helloTo)
@@ -31,7 +34,7 @@ namespace OpenTracing.Tutorial.Lesson02.Solution
         {
             using (var scope = _tracer.BuildSpan("print-hello").StartActive(true))
             {
-                Console.WriteLine(helloString);
+                _logger.LogInformation(helloString);
                 scope.Span.Log("WriteLine");
             }
         }
@@ -46,18 +49,21 @@ namespace OpenTracing.Tutorial.Lesson02.Solution
             }
         }
 
-        public static void Main(string[] args)
-        {
-            if (args.Length != 1)
-            {
-                throw new ArgumentException("Expecting one argument");
-            }
+        //public static void Main(string[] args)
+        //{
+        //    if (args.Length != 1)
+        //    {
+        //        throw new ArgumentException("Expecting one argument");
+        //    }
 
-            var helloTo = args[0];
-            using (var tracer = Tracing.Init("hello-world"))
-            {
-                new HelloActive(tracer).SayHello(helloTo);
-            }
-        }
+        //    using (var loggerFactory = new LoggerFactory().AddConsole())
+        //    {
+        //        var helloTo = args[0];
+        //        using (var tracer = Tracing.Init("hello-world", loggerFactory))
+        //        {
+        //            new HelloActive(tracer, loggerFactory).SayHello(helloTo);
+        //        }
+        //    }
+        //}
     }
 }

--- a/csharp/src/lesson03/README.md
+++ b/csharp/src/lesson03/README.md
@@ -119,9 +119,9 @@ request we need to call `_tracer.Inject` before building the HTTP request:
 
 ```csharp
 var span = scope.Span
-    .SetTag("span.kind", "client")  // or: Tags.SpanKind.Set(span, Tags.SpanKindClient);
-    .SetTag("http.method", "GET")   // or: Tags.HttpMethod.Set(span, "GET");
-    .SetTag("http.url", url);       // or: Tags.HttpUrl.Set(span, url);
+    .SetTag("span.kind", "client")  // or: .SetTag(Tags.SpanKind, Tags.SpanKindClient);
+    .SetTag("http.method", "GET")   // or: .SetTag(Tags.HttpMethod, "GET");
+    .SetTag("http.url", url);       // or: .SetTag(Tags.HttpUrl, url);
 
 var dictionary = new Dictionary<string, string>();
 _tracer.Inject(span.Context, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(dictionary));
@@ -154,21 +154,6 @@ public void ConfigureServices(IServiceCollection services)
     services.AddMvc();
 
     services.AddSingleton<ITracer, Tracer>(t => Tracer);
-}
-```
-
-And dispose of it during application shutdown:
-
-```csharp
-public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApplicationLifetime applicationLifetime)
-{
-    if (env.IsDevelopment())
-    {
-        app.UseDeveloperExceptionPage();
-    }
-
-    applicationLifetime.ApplicationStopping.Register(Tracer.Dispose);
-    app.UseMvc();
 }
 ```
 
@@ -208,7 +193,7 @@ public static IScope StartServerSpan(ITracer tracer, IDictionary<string, string>
     }
 
     // TODO could add more tags like http.url
-    return spanBuilder.WithTag(Tags.SpanKind.Key, Tags.SpanKindServer).StartActive(true);
+    return spanBuilder.WithTag(Tags.SpanKind, Tags.SpanKindServer).StartActive(true);
 }
 ```
 
@@ -243,110 +228,40 @@ Then run `Lesson03.Exercise.Client` in the terminal. You should see an output li
 Server output (ASP.NET Core Web Server):
 
 ```powershell
-info: Jaeger.Core.Reporters.LoggingReporter[0]
-Reporting span:
-{
-    "Context": {
-        "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-        ...
-    },
-    ...
-    "References": [
-        {
-        "Type": "child_of",
-        "Context": {
-            "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-            ...
-            }
-        }
-    ],
-    ...
-}
-info: Jaeger.Core.Reporters.LoggingReporter[0]
-Reporting span:
-{
-    "Context": {
-        "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-        ...
-    },
-    ...
-    "References": [
-        {
-        "Type": "child_of",
-        "Context": {
-            "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-            ...
-            }
-        }
-    ],
-    ...
-}
-info: Jaeger.Core.Reporters.LoggingReporter[0]
-Reporting span:
-{
-    "Context": {
-        "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-        ...
-    },
-    ...
-    "References": [
-        {
-        "Type": "child_of",
-        "Context": {
-            "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-            ...
-            }
-        }
-    ],
-    ...
-}
-info: Jaeger.Core.Reporters.LoggingReporter[0]
-Reporting span:
-{
-    "Context": {
-        "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-        ...
-    },
-    ...
-}
+$ dotnet run
+info: Jaeger.Configuration[0]
+      Initialized Jaeger.Tracer
+Hosting environment: Development
+Content root path: opentracing-tutorial\csharp\src\lesson03\example\Lesson03.Example.Server
+Now listening on: http://localhost:8081
+Application started. Press Ctrl+C to shut down.
+info: Jaeger.Reporters.LoggingReporter[0]
+      Span reported: 722582a9299820e258eee39b348263cc:1924ee38b5e4b7c3:52a7512a6a2d7ccc:1 - format-controller
+info: Jaeger.Reporters.LoggingReporter[0]
+      Span reported: 722582a9299820e258eee39b348263cc:291f14c7a20258ba:52a7512a6a2d7ccc:1 - Result ObjectResult
+info: Jaeger.Reporters.LoggingReporter[0]
+      Span reported: 722582a9299820e258eee39b348263cc:52a7512a6a2d7ccc:1e05b0ca172ad56e:1 - Action OpenTracing.Tutorial.Lesson03.Example.Server.Controllers.FormatController/Get
+info: Jaeger.Reporters.LoggingReporter[0]
+      Span reported: 722582a9299820e258eee39b348263cc:1e05b0ca172ad56e:92ffe8a50d62d2e:1 - HTTP GET
 ```
 
 Client terminal output:
 
 ```powershell
-info: Jaeger.Core.Reporters.LoggingReporter[0]
-Reporting span:
-{
-    "Context": {
-        "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-        ...
-    },
-    ...
-}
-Hello, Bryan!
-info: Jaeger.Core.Reporters.LoggingReporter[0]
-Reporting span:
-{
-    "Context": {
-        "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-        ...
-    },
-    ...
-}
-
-info: Jaeger.Core.Reporters.LoggingReporter[0]
-Reporting span:
-{
-    "Context": {
-        "TraceId": { "High": 15765884733735375433, "Low": 8792954367037605704 },
-        ...
-    },
-    ...
-}
+$ dotnet run Bryan
+info: Jaeger.Configuration[0]
+      Initialized Jaeger.Tracer
+info: Jaeger.Reporters.LoggingReporter[0]
+      Span reported: 722582a9299820e258eee39b348263cc:92ffe8a50d62d2e:58eee39b348263cc:1 - format-string
+info: OpenTracing.Tutorial.Lesson03.Example.Client.Hello[0]
+      Hello, Bryan!
+info: Jaeger.Reporters.LoggingReporter[0]
+      Span reported: 722582a9299820e258eee39b348263cc:2dc30af91f18b434:58eee39b348263cc:1 - print-hello
+info: Jaeger.Reporters.LoggingReporter[0]
+      Span reported: 722582a9299820e258eee39b348263cc:58eee39b348263cc:0:1 - say-hello
 ```
 
-Note how all recorded spans show the same trace ID
-`{ "High": 15765884733735375433, "Low": 8792954367037605704, "IsValid": true }`.
+Note how all recorded spans show the same trace ID `722582a9299820e258eee39b348263cc`.
 This is a sign of correct instrumentation. It is also a very useful debugging approach when something
 is wrong with tracing. A typical error is to miss the context propagation somwehere,
 either in-process or inter-process, which results in different trace IDs and broken

--- a/csharp/src/lesson03/solution/Lesson03.Solution.Client/Hello.cs
+++ b/csharp/src/lesson03/solution/Lesson03.Solution.Client/Hello.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using Microsoft.Extensions.Logging;
 using OpenTracing.Tutorial.Library;
 using OpenTracing.Propagation;
 using OpenTracing.Tag;
@@ -10,11 +11,13 @@ namespace OpenTracing.Tutorial.Lesson03.Solution.Client
     internal class Hello
     {
         private readonly ITracer _tracer;
+        private readonly ILogger<Hello> _logger;
         private readonly WebClient _webClient = new WebClient();
 
-        private Hello(ITracer tracer)
+        private Hello(ITracer tracer, ILoggerFactory loggerFactory)
         {
             _tracer = tracer;
+            _logger = loggerFactory.CreateLogger<Hello>();
         }
 
         private string FormatString(string helloTo)
@@ -22,10 +25,11 @@ namespace OpenTracing.Tutorial.Lesson03.Solution.Client
             using (var scope = _tracer.BuildSpan("format-string").StartActive(true))
             {
                 var url = $"http://localhost:8081/api/format/{helloTo}";
-                var span = _tracer.ActiveSpan;
-                Tags.SpanKind.Set(span, Tags.SpanKindClient);
-                Tags.HttpMethod.Set(span, "GET");
-                Tags.HttpUrl.Set(span, url);
+                var span = _tracer.ActiveSpan
+                    .SetTag(Tags.SpanKind, Tags.SpanKindClient)
+                    .SetTag(Tags.HttpMethod, "GET")
+                    .SetTag(Tags.HttpUrl, url);
+
                 var dictionary = new Dictionary<string, string>();
                 _tracer.Inject(span.Context, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(dictionary));
                 foreach (var entry in dictionary)
@@ -45,7 +49,7 @@ namespace OpenTracing.Tutorial.Lesson03.Solution.Client
         {
             using (var scope = _tracer.BuildSpan("print-hello").StartActive(true))
             {
-                Console.WriteLine(helloString);
+                _logger.LogInformation(helloString);
                 scope.Span.Log("WriteLine");
             }
         }
@@ -67,10 +71,13 @@ namespace OpenTracing.Tutorial.Lesson03.Solution.Client
                 throw new ArgumentException("Expecting one argument");
             }
 
-            var helloTo = args[0];
-            using (var tracer = Tracing.Init("hello-world"))
+            using (var loggerFactory = new LoggerFactory().AddConsole())
             {
-                new Hello(tracer).SayHello(helloTo);
+                var helloTo = args[0];
+                using (var tracer = Tracing.Init("hello-world", loggerFactory))
+                {
+                    new Hello(tracer, loggerFactory).SayHello(helloTo);
+                }
             }
         }
     }

--- a/csharp/src/lesson03/solution/Lesson03.Solution.Client/Lesson03.Solution.Client.csproj
+++ b/csharp/src/lesson03/solution/Lesson03.Solution.Client/Lesson03.Solution.Client.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/src/lesson03/solution/Lesson03.Solution.Server/Lesson03.Solution.Server.csproj
+++ b/csharp/src/lesson03/solution/Lesson03.Solution.Server/Lesson03.Solution.Server.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jaeger" Version="0.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.3" />
-    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.2.0" />
+    <PackageReference Include="Jaeger" Version="0.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.4" />
+    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/src/lesson03/solution/Lesson03.Solution.Server/Startup.cs
+++ b/csharp/src/lesson03/solution/Lesson03.Solution.Server/Startup.cs
@@ -1,8 +1,9 @@
-﻿using Jaeger.Core;
+﻿using Jaeger;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OpenTracing.Tutorial.Library;
 using OpenTracing.Util;
 
@@ -10,7 +11,8 @@ namespace OpenTracing.Tutorial.Lesson03.Solution.Server
 {
     public class Startup
     {
-        private static readonly Tracer Tracer = Tracing.Init("Webservice");
+        private static readonly ILoggerFactory LoggerFactory = new LoggerFactory().AddConsole();
+        private static readonly Tracer Tracer = Tracing.Init("Webservice", LoggerFactory);
 
         public Startup(IConfiguration configuration)
         {
@@ -29,14 +31,12 @@ namespace OpenTracing.Tutorial.Lesson03.Solution.Server
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApplicationLifetime applicationLifetime)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
-
-            applicationLifetime.ApplicationStopping.Register(Tracer.Dispose);
 
             app.UseMvc();
         }

--- a/csharp/src/lesson04/README.md
+++ b/csharp/src/lesson04/README.md
@@ -32,12 +32,15 @@ public static void Main(string[] args)
         throw new ArgumentException("Expecting two arguments, helloTo and greeting");
     }
 
-    var helloTo = args[0];
-    var greeting = args[1];
-    using (var tracer = Tracing.Init("say-hello"))
-    {
-        new Hello(tracer).SayHello(helloTo, greeting);
-    }
+	using (var loggerFactory = new LoggerFactory().AddConsole())
+	{
+		var helloTo = args[0];
+		var greeting = args[1];
+		using (var tracer = Tracing.Init("hello-world", loggerFactory))
+		{
+			new Hello(tracer, loggerFactory).SayHello(helloTo, greeting);
+		}
+	}
 }
 ```
 
@@ -70,7 +73,8 @@ $ dotnet run
 # client
 $ dotnet run Bryan Bonjour
 ...
-Bonjour, Bryan!
+info: OpenTracing.Tutorial.Lesson04.Example.Client.Hello[0]
+      Bonjour, Bryan!
 ...
 ```
 

--- a/csharp/src/lesson04/solution/Lesson04.Solution.Client/Hello.cs
+++ b/csharp/src/lesson04/solution/Lesson04.Solution.Client/Hello.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using Microsoft.Extensions.Logging;
 using OpenTracing.Tutorial.Library;
 using OpenTracing.Propagation;
 using OpenTracing.Tag;
@@ -10,11 +11,13 @@ namespace OpenTracing.Tutorial.Lesson04.Solution.Client
     internal class Hello
     {
         private readonly ITracer _tracer;
+        private readonly ILogger<Hello> _logger;
         private readonly WebClient _webClient = new WebClient();
 
-        private Hello(ITracer tracer)
+        private Hello(ITracer tracer, ILoggerFactory loggerFactory)
         {
             _tracer = tracer;
+            _logger = loggerFactory.CreateLogger<Hello>();
         }
 
         private string FormatString(string helloTo)
@@ -22,10 +25,11 @@ namespace OpenTracing.Tutorial.Lesson04.Solution.Client
             using (var scope = _tracer.BuildSpan("format-string").StartActive(true))
             {
                 var url = $"http://localhost:8081/api/format/{helloTo}";
-                var span = _tracer.ActiveSpan;
-                Tags.SpanKind.Set(span, Tags.SpanKindClient);
-                Tags.HttpMethod.Set(span, "GET");
-                Tags.HttpUrl.Set(span, url);
+                var span = _tracer.ActiveSpan
+                    .SetTag(Tags.SpanKind, Tags.SpanKindClient)
+                    .SetTag(Tags.HttpMethod, "GET")
+                    .SetTag(Tags.HttpUrl, url);
+
                 var dictionary = new Dictionary<string, string>();
                 _tracer.Inject(span.Context, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(dictionary));
                 foreach (var entry in dictionary)
@@ -45,7 +49,7 @@ namespace OpenTracing.Tutorial.Lesson04.Solution.Client
         {
             using (var scope = _tracer.BuildSpan("print-hello").StartActive(true))
             {
-                Console.WriteLine(helloString);
+                _logger.LogInformation(helloString);
                 scope.Span.Log("WriteLine");
             }
         }
@@ -68,11 +72,14 @@ namespace OpenTracing.Tutorial.Lesson04.Solution.Client
                 throw new ArgumentException("Expecting two arguments, helloTo and greeting");
             }
 
-            var helloTo = args[0];
-            var greeting = args[1];
-            using (var tracer = Tracing.Init("hello-world"))
+            using (var loggerFactory = new LoggerFactory().AddConsole())
             {
-                new Hello(tracer).SayHello(helloTo, greeting);
+                var helloTo = args[0];
+                var greeting = args[1];
+                using (var tracer = Tracing.Init("hello-world", loggerFactory))
+                {
+                    new Hello(tracer, loggerFactory).SayHello(helloTo, greeting);
+                }
             }
         }
     }

--- a/csharp/src/lesson04/solution/Lesson04.Solution.Client/Lesson04.Solution.Client.csproj
+++ b/csharp/src/lesson04/solution/Lesson04.Solution.Client/Lesson04.Solution.Client.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/src/lesson04/solution/Lesson04.Solution.Server/Lesson04.Solution.Server.csproj
+++ b/csharp/src/lesson04/solution/Lesson04.Solution.Server/Lesson04.Solution.Server.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jaeger" Version="0.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.3" />
-    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.2.0" />
+    <PackageReference Include="Jaeger" Version="0.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.4" />
+    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/src/lesson04/solution/Lesson04.Solution.Server/Startup.cs
+++ b/csharp/src/lesson04/solution/Lesson04.Solution.Server/Startup.cs
@@ -1,8 +1,9 @@
-﻿using Jaeger.Core;
+﻿using Jaeger;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OpenTracing.Tutorial.Library;
 using OpenTracing.Util;
 
@@ -10,7 +11,8 @@ namespace OpenTracing.Tutorial.Lesson04.Solution.Server
 {
     public class Startup
     {
-        private static readonly Tracer Tracer = Tracing.Init("Webservice");
+        private static readonly ILoggerFactory LoggerFactory = new LoggerFactory().AddConsole();
+        private static readonly Tracer Tracer = Tracing.Init("Webservice", LoggerFactory);
 
         public Startup(IConfiguration configuration)
         {
@@ -29,14 +31,12 @@ namespace OpenTracing.Tutorial.Lesson04.Solution.Server
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApplicationLifetime applicationLifetime)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
-
-            applicationLifetime.ApplicationStopping.Register(Tracer.Dispose);
 
             app.UseMvc();
         }


### PR DESCRIPTION
Targeting the latest libraries
- Jaeger 0.0.10 (+ OpenTracing 0.12.0)
- OpenTracing.Contrib.NetCore 0.4.0

There is a bug with `Jaeger 0.0.10` console logging right now. So we have to wait for `Jaeger 0.0.11` before merging.